### PR TITLE
feat: add --dir flag to zip and upload directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,21 @@
     "helpClass": "./dist/help",
     "topicSeparator": " ",
     "topics": {
-      "note": { "description": "Save and fetch encrypted notes" },
-      "file": { "description": "Upload and download encrypted files" },
-      "crypto": { "description": "Local encryption utilities" },
-      "server": { "description": "Server information and statistics" },
-      "config": { "description": "Manage the global not3 config file" }
+      "note": {
+        "description": "Save and fetch encrypted notes"
+      },
+      "file": {
+        "description": "Upload and download encrypted files"
+      },
+      "crypto": {
+        "description": "Local encryption utilities"
+      },
+      "server": {
+        "description": "Server information and statistics"
+      },
+      "config": {
+        "description": "Manage the global not3 config file"
+      }
     }
   },
   "scripts": {
@@ -59,7 +69,8 @@
     "@not3/sdk": "^2.0.5",
     "@oclif/core": "^4",
     "enquirer": "^2.4.1",
-    "qrcode-terminal": "^0.12.0"
+    "qrcode-terminal": "^0.12.0",
+    "yazl": "^3.3.1"
   },
   "devDependencies": {
     "@oclif/test": "^4",
@@ -67,6 +78,8 @@
     "@types/mocha": "^10",
     "@types/node": "^24.3.0",
     "@types/qrcode-terminal": "^0.12.2",
+    "@types/yauzl": "^3.4.0",
+    "@types/yazl": "^3.3.1",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
     "chai": "^4",
@@ -78,7 +91,8 @@
     "nock": "^14",
     "prettier": "^3.0.0",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.3",
+    "yauzl": "^3.4.0"
   },
   "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     dependencies:
       '@not3/sdk':
         specifier: ^2.0.5
-        version: 2.0.5
+        version: 2.0.5(supports-color@8.1.1)
       '@oclif/core':
         specifier: ^4
         version: 4.11.14
@@ -24,10 +24,13 @@ importers:
       qrcode-terminal:
         specifier: ^0.12.0
         version: 0.12.0
+      yazl:
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@oclif/test':
         specifier: ^4
-        version: 4.1.20(@oclif/core@4.11.14)
+        version: 4.1.20(@oclif/core@4.11.14)(supports-color@8.1.1)
       '@types/chai':
         specifier: ^4
         version: 4.3.20
@@ -40,24 +43,30 @@ importers:
       '@types/qrcode-terminal':
         specifier: ^0.12.2
         version: 0.12.2
+      '@types/yauzl':
+        specifier: ^3.4.0
+        version: 3.4.0
+      '@types/yazl':
+        specifier: ^3.3.1
+        version: 3.3.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.40.0
-        version: 8.62.1(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 8.62.1(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.40.0
-        version: 8.62.1(eslint@8.57.1)(typescript@5.9.3)
+        version: 8.62.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       chai:
         specifier: ^4
         version: 4.5.0
       eslint:
         specifier: ^8.0.0
-        version: 8.57.1
+        version: 8.57.1(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^10.1.1
-        version: 10.1.8(eslint@8.57.1)
+        version: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
       eslint-plugin-prettier:
         specifier: ^5.5.4
-        version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.4)
+        version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.4)
       generate-license-file:
         specifier: ^4.0.0
         version: 4.2.1(typescript@5.9.3)
@@ -76,6 +85,9 @@ importers:
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
+      yauzl:
+        specifier: ^3.4.0
+        version: 3.4.0
 
 packages:
 
@@ -313,6 +325,12 @@ packages:
   '@types/qrcode-terminal@0.12.2':
     resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
 
+  '@types/yauzl@3.4.0':
+    resolution: {integrity: sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==}
+
+  '@types/yazl@3.3.1':
+    resolution: {integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==}
+
   '@typescript-eslint/eslint-plugin@8.62.1':
     resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -483,6 +501,10 @@ packages:
 
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -1288,6 +1310,9 @@ packages:
   pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1628,6 +1653,13 @@ packages:
     resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
     engines: {node: '>=10'}
 
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
+
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -1657,14 +1689,14 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1(supports-color@8.1.1))':
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/eslintrc@2.1.4':
+  '@eslint/eslintrc@2.1.4(supports-color@8.1.1)':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -1682,7 +1714,7 @@ snapshots:
 
   '@gar/promise-retry@1.0.3': {}
 
-  '@humanwhocodes/config-array@0.13.0':
+  '@humanwhocodes/config-array@0.13.0(supports-color@8.1.1)':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3(supports-color@8.1.1)
@@ -1730,9 +1762,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@not3/sdk@2.0.5':
+  '@not3/sdk@2.0.5(supports-color@8.1.1)':
     dependencies:
-      axios: 1.18.1
+      axios: 1.18.1(supports-color@8.1.1)
       semver: 7.8.5
     transitivePeerDependencies:
       - debug
@@ -1877,7 +1909,7 @@ snapshots:
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
 
-  '@oclif/test@4.1.20(@oclif/core@4.11.14)':
+  '@oclif/test@4.1.20(@oclif/core@4.11.14)(supports-color@8.1.1)':
     dependencies:
       '@oclif/core': 4.11.14
       ansis: 3.17.0
@@ -1965,15 +1997,23 @@ snapshots:
 
   '@types/qrcode-terminal@0.12.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@types/yauzl@3.4.0':
+    dependencies:
+      '@types/node': 24.13.2
+
+  '@types/yazl@3.3.1':
+    dependencies:
+      '@types/node': 24.13.2
+
+  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/type-utils': 8.62.1(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.62.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@8.57.1(supports-color@8.1.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.62.1
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -1981,19 +2021,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.62.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.62.1(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.62.1
@@ -2011,13 +2051,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.62.1(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.62.1(eslint@8.57.1(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.62.1(supports-color@8.1.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@8.57.1(supports-color@8.1.1))(typescript@5.9.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -2025,9 +2065,9 @@ snapshots:
 
   '@typescript-eslint/types@8.62.1': {}
 
-  '@typescript-eslint/typescript-estree@8.62.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.62.1(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.62.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.62.1(supports-color@8.1.1)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.62.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/visitor-keys': 8.62.1
@@ -2040,13 +2080,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.1(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.62.1(eslint@8.57.1(supports-color@8.1.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
-      '@typescript-eslint/typescript-estree': 8.62.1(typescript@5.9.3)
-      eslint: 8.57.1
+      '@typescript-eslint/typescript-estree': 8.62.1(supports-color@8.1.1)(typescript@5.9.3)
+      eslint: 8.57.1(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2070,7 +2110,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -2114,11 +2154,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.18.1:
+  axios@1.18.1(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -2164,6 +2204,8 @@ snapshots:
       fill-range: 7.1.1
 
   browser-stdout@1.3.1: {}
+
+  buffer-crc32@1.0.0: {}
 
   buffer@5.7.1:
     dependencies:
@@ -2350,19 +2392,19 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@8.57.1):
+  eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)):
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
 
-  eslint-plugin-prettier@5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@8.57.1))(eslint@8.57.1)(prettier@3.9.4):
+  eslint-plugin-prettier@5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@8.57.1(supports-color@8.1.1)))(eslint@8.57.1(supports-color@8.1.1))(prettier@3.9.4):
     dependencies:
-      eslint: 8.57.1
+      eslint: 8.57.1(supports-color@8.1.1)
       prettier: 3.9.4
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
       '@types/eslint': 9.6.1
-      eslint-config-prettier: 10.1.8(eslint@8.57.1)
+      eslint-config-prettier: 10.1.8(eslint@8.57.1(supports-color@8.1.1))
 
   eslint-scope@7.2.2:
     dependencies:
@@ -2373,13 +2415,13 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@8.57.1:
+  eslint@8.57.1(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/eslintrc': 2.1.4
+      '@eslint/eslintrc': 2.1.4(supports-color@8.1.1)
       '@eslint/js': 8.57.1
-      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/config-array': 0.13.0(supports-color@8.1.1)
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.2
@@ -2609,9 +2651,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -3022,6 +3064,8 @@ snapshots:
 
   pathval@1.1.1: {}
 
+  pend@1.2.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -3323,6 +3367,14 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yn@3.1.1: {}
 

--- a/src/commands/file/upload.ts
+++ b/src/commands/file/upload.ts
@@ -1,20 +1,32 @@
-import { Args } from '@oclif/core';
+import { Args, Flags } from '@oclif/core';
 import { Crypto, FileUpload } from '@not3/sdk';
-import { existsSync, statSync } from 'fs';
-import { basename } from 'path';
+import { existsSync, mkdtempSync, rmSync, statSync } from 'fs';
+import { tmpdir } from 'os';
+import { basename, join, resolve } from 'path';
 import { BaseCommand } from '../../base.command';
 import { UsageError } from '../../lib/errors';
 import { seedFlag, serverFlags } from '../../lib/flags';
 import { readFileChunk } from '../../lib/io';
 import { fileShare } from '../../lib/share';
+import { zipDirectory } from '../../lib/zip';
 
 export default class FileUploadCommand extends BaseCommand {
   static description = 'Encrypt and upload a file';
   static aliases = ['u'];
   static args = {
-    input: Args.string({ required: true, description: 'File to upload' }),
+    input: Args.string({
+      required: true,
+      description: 'File (or, with --dir, directory) to upload',
+    }),
   };
-  static flags = { ...BaseCommand.baseFlags, ...serverFlags, seed: seedFlag };
+  static flags = {
+    ...BaseCommand.baseFlags,
+    ...serverFlags,
+    seed: seedFlag,
+    dir: Flags.boolean({
+      description: 'Zip the input directory and upload it as <dirname>.zip',
+    }),
+  };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(FileUploadCommand);
@@ -22,50 +34,75 @@ export default class FileUploadCommand extends BaseCommand {
     const reporter = this.makeReporter(s);
 
     if (!existsSync(args.input))
-      throw new UsageError(`File does not exist: ${args.input}`);
-    const stat = statSync(args.input);
-    if (stat.isDirectory()) throw new UsageError('Cannot upload a directory');
+      throw new UsageError(
+        `${flags.dir ? 'Directory' : 'File'} does not exist: ${args.input}`,
+      );
+    const isDirectory = statSync(args.input).isDirectory();
+    if (flags.dir && !isDirectory)
+      throw new UsageError(`Not a directory: ${args.input}`);
+    if (!flags.dir && isDirectory)
+      throw new UsageError(
+        'Cannot upload a directory (pass --dir to upload it as a zip archive)',
+      );
 
-    const seedGenerated = !flags.seed;
-    const seed = flags.seed ?? Crypto.generateSeed();
-    const fileName = basename(args.input).replaceAll(/[^a-zA-Z0-9.-]/g, '_');
-
-    const api = await this.makeApi(s);
-    const upload = new FileUpload(
-      api.files(),
-      fileName,
-      stat.size,
-      4,
-      true,
-      seed,
-    );
-    const total = upload.getChunkCount();
-    const bar = reporter.progress('Uploading', total);
-    let done = 0;
-    upload.onProgress((p) => {
-      const d = Object.values(p).filter((v) => v.state === 'done').length;
-      if (d > done) {
-        done = d;
-        bar.update(d);
+    let tmpDir: string | undefined;
+    try {
+      let input = args.input;
+      if (flags.dir) {
+        tmpDir = mkdtempSync(join(tmpdir(), 'not3-zip-'));
+        input = join(tmpDir, sanitize(basename(resolve(args.input)) + '.zip'));
+        reporter.info(`Zipping ${args.input}...`);
+        await zipDirectory(args.input, input);
       }
-    });
-    await upload.start((start, end) => readFileChunk(args.input, start, end));
-    bar.finish();
+      const stat = statSync(input);
 
-    const share = fileShare({
-      uiUrl: s.uiUrl,
-      apiServer: s.server,
-      id: upload.getID(),
-      seed,
-      fileName,
-    });
-    reporter.share({
-      kind: 'file',
-      id: upload.getID(),
-      seed,
-      seedGenerated,
-      url: share.url,
-      curl: share.curl,
-    });
+      const seedGenerated = !flags.seed;
+      const seed = flags.seed ?? Crypto.generateSeed();
+      const fileName = sanitize(basename(input));
+
+      const api = await this.makeApi(s);
+      const upload = new FileUpload(
+        api.files(),
+        fileName,
+        stat.size,
+        4,
+        true,
+        seed,
+      );
+      const total = upload.getChunkCount();
+      const bar = reporter.progress('Uploading', total);
+      let done = 0;
+      upload.onProgress((p) => {
+        const d = Object.values(p).filter((v) => v.state === 'done').length;
+        if (d > done) {
+          done = d;
+          bar.update(d);
+        }
+      });
+      await upload.start((start, end) => readFileChunk(input, start, end));
+      bar.finish();
+
+      const share = fileShare({
+        uiUrl: s.uiUrl,
+        apiServer: s.server,
+        id: upload.getID(),
+        seed,
+        fileName,
+      });
+      reporter.share({
+        kind: 'file',
+        id: upload.getID(),
+        seed,
+        seedGenerated,
+        url: share.url,
+        curl: share.curl,
+      });
+    } finally {
+      if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    }
   }
+}
+
+function sanitize(name: string): string {
+  return name.replaceAll(/[^a-zA-Z0-9.-]/g, '_');
 }

--- a/src/lib/zip.ts
+++ b/src/lib/zip.ts
@@ -1,0 +1,27 @@
+import { createWriteStream, readdirSync } from 'fs';
+import { join } from 'path';
+import yazl from 'yazl';
+
+function collectFiles(dir: string, prefix = ''): [string, string][] {
+  const files: [string, string][] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const abs = join(dir, entry.name);
+    const rel = prefix + entry.name;
+    if (entry.isDirectory()) files.push(...collectFiles(abs, rel + '/'));
+    else if (entry.isFile()) files.push([abs, rel]);
+  }
+  return files;
+}
+
+export function zipDirectory(dir: string, outFile: string): Promise<void> {
+  const zip = new yazl.ZipFile();
+  for (const [abs, rel] of collectFiles(dir)) zip.addFile(abs, rel);
+  zip.end();
+  return new Promise((resolve, reject) => {
+    zip.outputStream
+      .pipe(createWriteStream(outFile))
+      .on('close', () => resolve())
+      .on('error', reject);
+    zip.outputStream.on('error', reject);
+  });
+}

--- a/test/commands/file.test.ts
+++ b/test/commands/file.test.ts
@@ -1,0 +1,96 @@
+import { runCommand } from '@oclif/test';
+import { expect } from 'chai';
+import { mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import nock from 'nock';
+import not3Sdk from '@not3/sdk';
+
+const { Crypto } = not3Sdk;
+
+const SERVER = 'http://localhost:9999';
+const INFO = {
+  version: 'IN-DEV',
+  availableTokens: 100,
+  maxStorageTimeDays: 30,
+  fileTransferEnabled: true,
+  fileTransferMaxSize: 0,
+  privateMode: false,
+  time: 0,
+  totalNotes: 0,
+  requestsInLastMinute: 0,
+  notExpiredFailedRequests: 0,
+  currentFiles: 0,
+  currentUploadingFiles: 0,
+  bannedIps: 0,
+};
+
+describe('not3 file upload --dir', () => {
+  afterEach(() => nock.cleanAll());
+
+  it('rejects --dir when the input is not a directory', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'not3-test-'));
+    const file = join(base, 'plain.txt');
+    writeFileSync(file, 'hi');
+    const { error } = await runCommand([
+      'file',
+      'upload',
+      file,
+      '--dir',
+      '-s',
+      SERVER,
+    ]);
+    expect(error?.message).to.contain('Not a directory');
+  });
+
+  it('hints at --dir when a directory is uploaded without it', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'not3-test-'));
+    const { error } = await runCommand(['file', 'upload', base, '-s', SERVER]);
+    expect(error?.message).to.contain('--dir');
+  });
+
+  it('zips the directory and uploads it as <dirname>.zip', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'not3-test-'));
+    const dir = join(base, 'demo+data');
+    mkdirSync(join(dir, 'sub'), { recursive: true });
+    writeFileSync(join(dir, 'a.txt'), 'alpha');
+    writeFileSync(join(dir, 'sub', 'b.txt'), 'beta');
+
+    let postedName = '';
+    nock(SERVER).persist().get('/info').reply(200, INFO);
+    nock(SERVER)
+      .post('/file/upload', (body) => {
+        postedName = (body as { name: string }).name;
+        return true;
+      })
+      .reply(201, { id: 'file-1' });
+    nock(SERVER)
+      .get('/file/upload/file-1')
+      .query(true)
+      .reply(200, { url: `${SERVER}/chunk/1` });
+    nock(SERVER).put('/chunk/1').reply(200, '', { ETag: '"etag-1"' });
+    nock(SERVER).put('/file/upload/file-1').reply(200);
+
+    const { stdout, error } = await runCommand([
+      'file',
+      'upload',
+      dir,
+      '--dir',
+      '-s',
+      SERVER,
+      '--seed',
+      Crypto.generateSeed(),
+      '--output-mode',
+      'raw',
+    ]);
+
+    expect(error).to.equal(undefined);
+    expect(stdout).to.equal('file-1');
+    expect(postedName).to.equal('demo_data.zip');
+    // the temporary zip must be cleaned up afterwards
+    const leftovers = readdirSync(tmpdir()).filter((e) =>
+      e.startsWith('not3-zip-'),
+    );
+    expect(leftovers).to.have.length(0);
+  });
+});

--- a/test/lib/zip.test.ts
+++ b/test/lib/zip.test.ts
@@ -1,0 +1,68 @@
+import { expect } from 'chai';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import yauzl from 'yauzl';
+import { zipDirectory } from '../../src/lib/zip';
+
+function readZipEntries(zipPath: string): Promise<Map<string, string>> {
+  return new Promise((resolve, reject) => {
+    const entries = new Map<string, string>();
+    yauzl.open(zipPath, { lazyEntries: true }, (err, zip) => {
+      if (err) return reject(err);
+      zip.on('error', reject);
+      zip.on('entry', (entry) => {
+        if (entry.fileName.endsWith('/')) {
+          entries.set(entry.fileName, '');
+          zip.readEntry();
+          return;
+        }
+        zip.openReadStream(entry, (streamErr, stream) => {
+          if (streamErr) return reject(streamErr);
+          const parts: Buffer[] = [];
+          stream.on('data', (c: Buffer) => parts.push(c));
+          stream.on('end', () => {
+            entries.set(entry.fileName, Buffer.concat(parts).toString());
+            zip.readEntry();
+          });
+          stream.on('error', reject);
+        });
+      });
+      zip.on('end', () => resolve(entries));
+      zip.readEntry();
+    });
+  });
+}
+
+describe('zipDirectory', () => {
+  it('zips nested files with forward-slash relative paths', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'not3-'));
+    const dir = join(base, 'payload');
+    mkdirSync(join(dir, 'sub', 'deep'), { recursive: true });
+    writeFileSync(join(dir, 'root.txt'), 'root content');
+    writeFileSync(join(dir, 'sub', 'nested.txt'), 'nested content');
+    writeFileSync(join(dir, 'sub', 'deep', 'leaf.txt'), 'leaf content');
+
+    const out = join(base, 'payload.zip');
+    await zipDirectory(dir, out);
+
+    const entries = await readZipEntries(out);
+    expect(entries.get('root.txt')).to.equal('root content');
+    expect(entries.get('sub/nested.txt')).to.equal('nested content');
+    expect(entries.get('sub/deep/leaf.txt')).to.equal('leaf content');
+  });
+
+  it('produces a valid empty archive for an empty directory', async () => {
+    const base = mkdtempSync(join(tmpdir(), 'not3-'));
+    const dir = join(base, 'empty');
+    mkdirSync(dir);
+
+    const out = join(base, 'empty.zip');
+    await zipDirectory(dir, out);
+
+    const entries = await readZipEntries(out);
+    expect([...entries.keys()].filter((k) => !k.endsWith('/'))).to.have.length(
+      0,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a `--dir` flag to `not3 file upload` that zips a target directory into a temp file (named `<dirname>.zip`) and uploads that archive instead
- Uploading a directory without `--dir` now hints that the flag exists; the temp zip is always cleaned up, even on failure

## Test plan
- [x] `pnpm test` (88 passing)
- [x] `pnpm lint`
- [x] `pnpm build:tsc`
- [x] Manually ran `not3 file upload --help` and exercised both error paths via `bin/dev.js`