### PR TITLE
feat: add support for stats password in config commands and server stats

### DIFF
--- a/src/base.command.ts
+++ b/src/base.command.ts
@@ -36,6 +36,7 @@ export abstract class BaseCommand extends Command {
     return resolveSettings(this.userConfig(), {
       server: flags.server as string | undefined,
       password: flags.password as string | undefined,
+      statsPassword: flags['stats-password'] as string | undefined,
       mode: flags.mode as CryptoMode | undefined,
       editor: flags.editor as string | undefined,
       outputMode: flags['output-mode'] as OutputModeSetting | undefined,

--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -23,11 +23,11 @@ export default class ConfigGet extends BaseCommand {
       );
     }
     const s = this.resolveFrom(flags);
-    if (key === 'password') {
-      this.log(s.password ? '••••' : '(not set)');
+    if (key === 'password' || key === 'statsPassword') {
+      this.log(s[key] ? '••••' : '(not set)');
       return;
     }
-    const value = s[key as Exclude<ConfigKey, 'password'>];
+    const value = s[key as Exclude<ConfigKey, 'password' | 'statsPassword'>];
     this.log(value === undefined ? '(not set)' : String(value));
   }
 }

--- a/src/commands/config/list.ts
+++ b/src/commands/config/list.ts
@@ -18,6 +18,7 @@ export default class ConfigList extends BaseCommand {
     if (!flags['show-secrets'] && shown.servers) {
       for (const entry of Object.values(shown.servers)) {
         if (entry.password) entry.password = '••••';
+        if (entry.statsPassword) entry.statsPassword = '••••';
       }
     }
     this.log(JSON.stringify(shown, null, 2));

--- a/src/commands/config/set.ts
+++ b/src/commands/config/set.ts
@@ -36,11 +36,15 @@ export default class ConfigSet extends BaseCommand {
     }
     const cfg = loadConfig(this.config.configDir);
     switch (key) {
-      case 'password': {
+      case 'password':
+      case 'statsPassword': {
         const server = normalizeServerUrl(
           flags.server ?? cfg.server ?? DEFAULTS.server,
         );
-        cfg.servers = { ...cfg.servers, [server]: { password: args.value } };
+        cfg.servers = {
+          ...cfg.servers,
+          [server]: { ...cfg.servers?.[server], [key]: args.value },
+        };
         break;
       }
       case 'server':
@@ -71,6 +75,7 @@ export default class ConfigSet extends BaseCommand {
         break;
     }
     saveConfig(this.config.configDir, cfg);
-    this.log(`Set ${key}${key === 'password' ? ' (bound to its server)' : ''}`);
+    const bound = key === 'password' || key === 'statsPassword';
+    this.log(`Set ${key}${bound ? ' (bound to its server)' : ''}`);
   }
 }

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -30,12 +30,12 @@ export default class ConfigUnset extends BaseCommand {
       );
     }
     const cfg = loadConfig(this.config.configDir);
-    if (key === 'password') {
+    if (key === 'password' || key === 'statsPassword') {
       const server = normalizeServerUrl(
         flags.server ?? cfg.server ?? DEFAULTS.server,
       );
       if (cfg.servers?.[server]) {
-        delete cfg.servers[server].password;
+        delete cfg.servers[server][key];
         if (Object.keys(cfg.servers[server]).length === 0)
           delete cfg.servers[server];
       }

--- a/src/commands/server/stats.ts
+++ b/src/commands/server/stats.ts
@@ -1,14 +1,18 @@
 import { BaseCommand } from '../../base.command';
-import { serverFlags } from '../../lib/flags';
+import { serverFlags, statsPasswordFlag } from '../../lib/flags';
 
 export default class ServerStats extends BaseCommand {
   static description = 'Show usage statistics of the API server';
-  static flags = { ...BaseCommand.baseFlags, ...serverFlags };
+  static flags = {
+    ...BaseCommand.baseFlags,
+    ...serverFlags,
+    'stats-password': statsPasswordFlag,
+  };
 
   async run(): Promise<void> {
     const { flags } = await this.parse(ServerStats);
     const s = this.resolveFrom(flags);
     const api = await this.makeApi(s);
-    this.makeReporter(s).json(await api.system().stats(s.password));
+    this.makeReporter(s).json(await api.system().stats(s.statsPassword));
   }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,7 +13,7 @@ export type OutputModeSetting = 'auto' | 'pretty' | 'simple' | 'stdout' | 'raw';
 
 export interface Not3Config {
   server?: string;
-  servers?: Record<string, { password?: string }>;
+  servers?: Record<string, { password?: string; statsPassword?: string }>;
   mode?: CryptoMode;
   editor?: string;
   versionCheck?: boolean;
@@ -32,6 +32,7 @@ export const DEFAULTS = {
 export const CONFIG_KEYS = [
   'server',
   'password',
+  'statsPassword',
   'mode',
   'editor',
   'versionCheck',
@@ -77,6 +78,7 @@ export function saveConfig(configDir: string, cfg: Not3Config): void {
 export interface FlagSettings {
   server?: string;
   password?: string;
+  statsPassword?: string;
   mode?: CryptoMode;
   editor?: string;
   outputMode?: OutputModeSetting;
@@ -86,6 +88,7 @@ export interface FlagSettings {
 export interface ResolvedSettings {
   server: string;
   password?: string;
+  statsPassword?: string;
   mode: CryptoMode;
   editor?: string;
   versionCheck: boolean;
@@ -100,10 +103,12 @@ export function resolveSettings(
   const server = normalizeServerUrl(
     flags.server ?? cfg.server ?? DEFAULTS.server,
   );
-  const stored = cfg.servers?.[server]?.password;
+  const stored = cfg.servers?.[server];
+  const password = flags.password ?? stored?.password;
   return {
     server,
-    password: flags.password ?? stored,
+    password,
+    statsPassword: flags.statsPassword ?? stored?.statsPassword ?? password,
     mode: flags.mode ?? cfg.mode ?? DEFAULTS.mode,
     editor: flags.editor ?? cfg.editor,
     versionCheck: flags.noVersionCheck

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -17,6 +17,11 @@ export const serverFlags = {
   }),
 };
 
+export const statsPasswordFlag = Flags.string({
+  description: 'Stats password (defaults to the server password)',
+  env: 'NOT3_STATS_PASSWORD',
+});
+
 export const seedFlag = Flags.string({
   description:
     'Encryption seed (prompted for on a TTY when required and omitted)',

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -60,6 +60,48 @@ describe('not3 config', () => {
     expect(secrets.stdout).to.contain('topsecret');
   });
 
+  it('stores statsPassword per server, independent of the password', async () => {
+    await runCommand(['config', 'set', 'server', 'https://self.example']);
+    await runCommand(['config', 'set', 'statsPassword', 'stats1']);
+    const cfg = readCfg() as {
+      servers: Record<string, { password?: string; statsPassword?: string }>;
+    };
+    expect(cfg.servers['https://self.example'].statsPassword).to.equal(
+      'stats1',
+    );
+    expect(cfg.servers['https://self.example'].password).to.equal(undefined);
+  });
+
+  it('masks statsPassword in get and list, reveals with --show-secrets', async () => {
+    await runCommand(['config', 'set', 'statsPassword', 'statssecret']);
+    const get = await runCommand(['config', 'get', 'statsPassword']);
+    expect(get.stdout).to.not.contain('statssecret');
+    expect(get.stdout).to.contain('••••');
+    const list = await runCommand(['config', 'list']);
+    expect(list.stdout).to.not.contain('statssecret');
+    const secrets = await runCommand(['config', 'list', '--show-secrets']);
+    expect(secrets.stdout).to.contain('statssecret');
+  });
+
+  it('unsets statsPassword without touching the password', async () => {
+    await runCommand(['config', 'set', 'password', 'pw1']);
+    await runCommand(['config', 'set', 'statsPassword', 'stats1']);
+    await runCommand(['config', 'unset', 'statsPassword']);
+    const cfg = readCfg() as {
+      servers: Record<string, { password?: string; statsPassword?: string }>;
+    };
+    const entry = cfg.servers['https://api.not-th.re'];
+    expect(entry.password).to.equal('pw1');
+    expect(entry.statsPassword).to.equal(undefined);
+  });
+
+  it('unsets statsPassword and cleans up empty server entries', async () => {
+    await runCommand(['config', 'set', 'statsPassword', 'stats1']);
+    await runCommand(['config', 'unset', 'statsPassword']);
+    const cfg = readCfg() as { servers?: Record<string, unknown> };
+    expect(cfg.servers ?? {}).to.deep.equal({});
+  });
+
   it('unsets password and cleans up empty server entries', async () => {
     await runCommand(['config', 'set', 'password', 'pw1']);
     await runCommand(['config', 'unset', 'password']);

--- a/test/commands/server.test.ts
+++ b/test/commands/server.test.ts
@@ -48,4 +48,42 @@ describe('not3 server', () => {
     ]);
     expect(JSON.parse(stdout).anything).to.equal(true);
   });
+
+  it('stats sends the dedicated stats password', async () => {
+    nock(SERVER).get('/info').reply(200, INFO);
+    nock(SERVER)
+      .get('/stats')
+      .query({ password: 'statspw' })
+      .reply(200, { ok: true });
+    const { stdout } = await runCommand([
+      'server',
+      'stats',
+      '-s',
+      SERVER,
+      '--stats-password',
+      'statspw',
+      '--output-mode',
+      'simple',
+    ]);
+    expect(JSON.parse(stdout).ok).to.equal(true);
+  });
+
+  it('stats falls back to the server password when no stats password is given', async () => {
+    nock(SERVER).get('/info').reply(200, INFO);
+    nock(SERVER)
+      .get('/stats')
+      .query({ password: 'serverpw' })
+      .reply(200, { ok: true });
+    const { stdout } = await runCommand([
+      'server',
+      'stats',
+      '-s',
+      SERVER,
+      '-p',
+      'serverpw',
+      '--output-mode',
+      'simple',
+    ]);
+    expect(JSON.parse(stdout).ok).to.equal(true);
+  });
 });

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -85,6 +85,49 @@ describe('resolveSettings', () => {
       'flag',
     );
   });
+  it('resolves the stored statsPassword for the configured server', () => {
+    const withStats = {
+      server: 'https://self.example',
+      servers: {
+        'https://self.example': { password: 'pw1', statsPassword: 'stats1' },
+      },
+    };
+    expect(resolveSettings(withStats, {}).statsPassword).to.equal('stats1');
+  });
+  it('statsPassword falls back to the regular password when unset', () => {
+    expect(resolveSettings(cfg, {}).statsPassword).to.equal('pw1');
+    expect(resolveSettings({}, { password: 'flag' }).statsPassword).to.equal(
+      'flag',
+    );
+  });
+  it('allows a statsPassword without any instance password', () => {
+    const publicWithStats = {
+      server: 'https://self.example',
+      servers: { 'https://self.example': { statsPassword: 'stats1' } },
+    };
+    const s = resolveSettings(publicWithStats, {});
+    expect(s.password).to.equal(undefined);
+    expect(s.statsPassword).to.equal('stats1');
+  });
+  it('flag statsPassword beats stored values', () => {
+    const withStats = {
+      server: 'https://self.example',
+      servers: { 'https://self.example': { statsPassword: 'stats1' } },
+    };
+    expect(
+      resolveSettings(withStats, { statsPassword: 'flag' }).statsPassword,
+    ).to.equal('flag');
+  });
+  it('does NOT leak the stored statsPassword to a different server', () => {
+    const withStats = {
+      server: 'https://self.example',
+      servers: { 'https://self.example': { statsPassword: 'stats1' } },
+    };
+    expect(
+      resolveSettings(withStats, { server: 'https://other.example' })
+        .statsPassword,
+    ).to.equal(undefined);
+  });
   it('noVersionCheck flag wins over config', () => {
     expect(
       resolveSettings({ versionCheck: true }, { noVersionCheck: true })


### PR DESCRIPTION
## Summary
- The `server stats` command now uses a dedicated `--stats-password`/`NOT3_STATS_PASSWORD` flag instead of reusing the instance password
- `config set/get/unset statsPassword` store it per-server, independent of the regular password (e.g. a public instance with no instance password but a protected stats endpoint)
- Resolution falls back to the regular password when no stats password is set, so existing setups are unaffected
- Fixed a latent bug in `config set` where setting one of `password`/`statsPassword` would silently wipe the other from the same server entry

## Test plan
- [x] `pnpm test` — 94 passing, including new coverage for resolution precedence, no-instance-password scenario, masking, and unset cleanup
- [x] `pnpm lint`, `tsc --noEmit`, `prettier --check`
- [x] Manually exercised `server stats --help`, `config set/get/unset statsPassword`, and `config list` against a local config dir