### PR TITLE
feat: add `not3 config edit` command

### DIFF
--- a/src/commands/config/edit.ts
+++ b/src/commands/config/edit.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { BaseCommand } from '../../base.command';
+import {
+  configFile,
+  loadConfig,
+  Not3Config,
+  saveConfig,
+} from '../../lib/config';
+import { findEditor, openEditor } from '../../lib/editor';
+import { editorFlag } from '../../lib/flags';
+
+export default class ConfigEdit extends BaseCommand {
+  static description = 'Open the global config file in your editor';
+  static flags = { ...BaseCommand.baseFlags, editor: editorFlag };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(ConfigEdit);
+    let stored: Not3Config = {};
+    try {
+      stored = loadConfig(this.config.configDir);
+    } catch {
+      /* invalid JSON on disk — the raw content is still editable below */
+    }
+    const editor = findEditor(flags.editor ?? stored.editor);
+    const file = configFile(this.config.configDir);
+    const original = existsSync(file) ? readFileSync(file, 'utf8') : '{}\n';
+    const tempFile = join(
+      tmpdir(),
+      `not3-config-${process.pid}-${Math.random().toString(36).slice(2)}.json`,
+    );
+    writeFileSync(tempFile, original, { mode: 0o600 });
+    try {
+      await openEditor(editor, tempFile);
+      const edited = readFileSync(tempFile, 'utf8');
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(edited);
+      } catch {
+        throw new Error(
+          'Edited config is not valid JSON, aborting (config unchanged)',
+        );
+      }
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        Array.isArray(parsed)
+      )
+        throw new Error(
+          'Edited config must be a JSON object, aborting (config unchanged)',
+        );
+      saveConfig(this.config.configDir, parsed as Not3Config);
+      this.log(`Saved ${file}`);
+    } finally {
+      try {
+        unlinkSync(tempFile);
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}

--- a/src/commands/crypto/edit.ts
+++ b/src/commands/crypto/edit.ts
@@ -1,29 +1,12 @@
 import { Args } from '@oclif/core';
 import { Crypto } from '@not3/sdk';
-import { spawn, spawnSync } from 'child_process';
 import { readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { BaseCommand } from '../../base.command';
-import { UsageError } from '../../lib/errors';
+import { findEditor, openEditor } from '../../lib/editor';
 import { editorFlag, modeFlag, outputFlag, seedFlag } from '../../lib/flags';
 import { resolveSeed } from '../../lib/input';
-
-function onPath(cmd: string): boolean {
-  return spawnSync('which', [cmd]).status === 0;
-}
-
-function findEditor(preferred?: string): string {
-  if (preferred) return preferred;
-  if (process.env.EDITOR && onPath(process.env.EDITOR))
-    return process.env.EDITOR;
-  for (const candidate of ['nano', 'vim', 'vi']) {
-    if (onPath(candidate)) return candidate;
-  }
-  throw new UsageError(
-    'No terminal editor found; pass one with -e/--editor or set NOT3_EDITOR',
-  );
-}
 
 export default class CryptoEdit extends BaseCommand {
   static description = 'Edit a locally stored encrypted file in your editor';
@@ -64,21 +47,7 @@ export default class CryptoEdit extends BaseCommand {
     );
     writeFileSync(tempFile, dec, { mode: 0o600 });
     try {
-      const code = await new Promise<number>((resolve, reject) => {
-        const child = spawn(editor, [tempFile], { stdio: 'inherit' });
-        child.on('error', (err) =>
-          reject(
-            new UsageError(
-              `Failed to start editor "${editor}": ${err.message}`,
-            ),
-          ),
-        );
-        child.on('exit', (c) => resolve(c ?? 1));
-      });
-      if (code !== 0)
-        throw new Error(
-          `Editor exited with code ${code}, aborting (file unchanged)`,
-        );
+      await openEditor(editor, tempFile);
       const edited = readFileSync(tempFile, 'utf8');
       const enc = await Crypto.encrypt(edited, key, s.mode);
       const target = flags.output ?? args.file;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -51,7 +51,7 @@ export function normalizeServerUrl(raw: string): string {
   return `${url.protocol}//${url.host}${path}`;
 }
 
-function configFile(configDir: string): string {
+export function configFile(configDir: string): string {
   return join(configDir, 'config.json');
 }
 

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -1,0 +1,34 @@
+import { spawn, spawnSync } from 'child_process';
+import { UsageError } from './errors';
+
+function onPath(cmd: string): boolean {
+  return spawnSync('which', [cmd]).status === 0;
+}
+
+export function findEditor(preferred?: string): string {
+  if (preferred) return preferred;
+  if (process.env.EDITOR && onPath(process.env.EDITOR))
+    return process.env.EDITOR;
+  for (const candidate of ['nano', 'vim', 'vi']) {
+    if (onPath(candidate)) return candidate;
+  }
+  throw new UsageError(
+    'No terminal editor found; pass one with -e/--editor or set NOT3_EDITOR',
+  );
+}
+
+export async function openEditor(editor: string, file: string): Promise<void> {
+  const code = await new Promise<number>((resolve, reject) => {
+    const child = spawn(editor, [file], { stdio: 'inherit' });
+    child.on('error', (err) =>
+      reject(
+        new UsageError(`Failed to start editor "${editor}": ${err.message}`),
+      ),
+    );
+    child.on('exit', (c) => resolve(c ?? 1));
+  });
+  if (code !== 0)
+    throw new Error(
+      `Editor exited with code ${code}, aborting (file unchanged)`,
+    );
+}

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -1,6 +1,13 @@
 import { runCommand } from '@oclif/test';
 import { expect } from 'chai';
-import { mkdtempSync, readFileSync } from 'fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -102,5 +109,92 @@ describe('not3 config', () => {
     ]);
     expect(server.error).to.equal(undefined);
     expect(server.stdout).to.contain('https://other.example');
+  });
+});
+
+describe('not3 config edit', () => {
+  let home: string;
+  let work: string;
+  const env = process.env;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'not3-cfg-'));
+    work = mkdtempSync(join(tmpdir(), 'not3-cfg-edit-'));
+    process.env = { ...env, XDG_CONFIG_HOME: join(home, '.config') };
+  });
+  afterEach(() => {
+    process.env = env;
+  });
+
+  function cfgFile(): string {
+    return join(home, '.config', 'not3', 'config.json');
+  }
+
+  function readCfg(): Record<string, unknown> {
+    return JSON.parse(readFileSync(cfgFile(), 'utf8'));
+  }
+
+  function fakeEditor(script: string): string {
+    const editor = join(work, 'editor.sh');
+    writeFileSync(editor, `#!/bin/sh\n${script}\n`);
+    chmodSync(editor, 0o755);
+    return editor;
+  }
+
+  it('round-trips the config through a fake editor', async () => {
+    await runCommand(['config', 'set', 'mode', 'gcm']);
+    const seen = join(work, 'seen.txt');
+    const editor = fakeEditor(
+      `cat "$1" > "${seen}"\nprintf '{"mode":"cbc"}' > "$1"`,
+    );
+    const { error } = await runCommand(['config', 'edit', '-e', editor]);
+    expect(error).to.equal(undefined);
+    expect(readCfg()).to.deep.equal({ mode: 'cbc' });
+    expect(JSON.parse(readFileSync(seen, 'utf8'))).to.deep.equal({
+      mode: 'gcm',
+    });
+  });
+
+  it('creates the config file when none exists yet', async () => {
+    const editor = fakeEditor(`printf '{"mode":"gcm"}' > "$1"`);
+    const { error } = await runCommand(['config', 'edit', '-e', editor]);
+    expect(error).to.equal(undefined);
+    expect(readCfg()).to.deep.equal({ mode: 'gcm' });
+  });
+
+  it('rejects invalid JSON and leaves the config untouched', async () => {
+    await runCommand(['config', 'set', 'mode', 'gcm']);
+    const editor = fakeEditor(`printf 'not json{' > "$1"`);
+    const { error } = await runCommand(['config', 'edit', '-e', editor]);
+    expect(error?.message ?? '').to.match(/JSON/);
+    expect(readCfg()).to.deep.equal({ mode: 'gcm' });
+  });
+
+  it('can repair a config file that is currently invalid JSON', async () => {
+    mkdirSync(join(home, '.config', 'not3'), { recursive: true });
+    writeFileSync(cfgFile(), 'broken{');
+    const seen = join(work, 'seen.txt');
+    const editor = fakeEditor(`cat "$1" > "${seen}"\nprintf '{}' > "$1"`);
+    const { error } = await runCommand(['config', 'edit', '-e', editor]);
+    expect(error).to.equal(undefined);
+    expect(readFileSync(seen, 'utf8')).to.equal('broken{');
+    expect(readCfg()).to.deep.equal({});
+  });
+
+  it('aborts without saving when the editor exits non-zero', async () => {
+    await runCommand(['config', 'set', 'mode', 'gcm']);
+    const editor = fakeEditor(`printf '{}' > "$1"\nexit 3`);
+    const { error } = await runCommand(['config', 'edit', '-e', editor]);
+    expect(error?.message ?? '').to.match(/exited/);
+    expect(readCfg()).to.deep.equal({ mode: 'gcm' });
+  });
+
+  it('uses the editor stored in the config when no flag is given', async () => {
+    const editor = fakeEditor(`printf '{"mode":"gcm"}' > "$1"`);
+    await runCommand(['config', 'set', 'editor', editor]);
+    const { error } = await runCommand(['config', 'edit']);
+    expect(error).to.equal(undefined);
+    expect(readCfg().mode).to.equal('gcm');
+    expect(existsSync(cfgFile())).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `not3 config edit`, which opens `config.json` in the user's editor for direct editing, resolving the editor the same way `crypto edit` does (`-e`/`NOT3_EDITOR` → `editor` config key → `$EDITOR` → nano/vim/vi)
- Extracts the shared editor-resolution/spawn logic out of `crypto edit` into `src/lib/editor.ts` so both commands use it
- Validates the edited content parses as a JSON object before saving via `saveConfig`; edits the raw file text (not `loadConfig`) so it can also repair a config file that's currently invalid JSON

## Test plan
- [x] `pnpm test` — 89 passing, including 6 new `config edit` tests (round-trip, missing config, invalid JSON, non-object JSON, non-zero editor exit, repairing broken JSON, picking up the `editor` config key)
- [x] `pnpm lint` / prettier check / `pnpm build:tsc` clean
- [x] Manually drove the built CLI with fake shell-script editors: happy path, invalid JSON, JSON array, non-zero exit, repairing a corrupted config, nonexistent editor binary, and confirmed no leftover temp files